### PR TITLE
Implements ItemLookup interface of WikibaseDataModel

### DIFF
--- a/src/Api/ItemApiLookup.php
+++ b/src/Api/ItemApiLookup.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Wikibase\Api;
+
+use Wikibase\Api\Service\RevisionGetter;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\ItemLookup;
+use Wikibase\DataModel\Entity\ItemNotFoundException;
+
+/**
+ * @author Thomas Pellissier-Tanon
+ */
+class ItemApiLookup implements ItemLookup {
+
+	/**
+	 * @var RevisionGetter
+	 */
+	private $revisionGetter;
+
+	/**
+	 * @param RevisionGetter $revisionGetter
+	 */
+	public function __construct( RevisionGetter $revisionGetter ) {
+		$this->revisionGetter = $revisionGetter;
+	}
+
+	/**
+	 * @see ItemLookup::getItemForId
+	 */
+	public function getItemForId( ItemId $itemId ) {
+		$revision = $this->revisionGetter->getFromId( $itemId );
+
+		if( !$revision ) {
+			throw new ItemNotFoundException( $itemId );
+		}
+
+		return $revision->getContent()->getData();
+	}
+}

--- a/src/Api/ItemApiLookup.php
+++ b/src/Api/ItemApiLookup.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Entity\ItemLookup;
 use Wikibase\DataModel\Entity\ItemNotFoundException;
 
 /**
- * @author Thomas Pellissier-Tanon
+ * @author Thomas Pellissier Tanon
  */
 class ItemApiLookup implements ItemLookup {
 

--- a/tests/unit/Api/RevisionGetterTest.php
+++ b/tests/unit/Api/RevisionGetterTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Wikibase\Api\Test;
+
+use Mediawiki\DataModel\Revision;
+use Wikibase\Api\ItemApiLookup;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\ItemContent;
+
+/**
+ * @covers Wikibase\Api\ItemApiLookup
+ */
+class ItemApiLookupTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGetItemForId() {
+		$revisionGetterMock = $this->getMockBuilder( '\Wikibase\Api\Service\RevisionGetter' )
+			->disableOriginalConstructor()
+			->getMock();
+		$revisionGetterMock->expects( $this->once() )
+			->method( 'getFromId' )
+			->with( $this->equalTo( new ItemId( 'Q42' ) ) )
+			->will( $this->returnValue( new Revision( new ItemContent( new Item( new ItemId( 'Q42' ) ) ) ) ) );
+
+		$itemApiLookup = new ItemApiLookup( $revisionGetterMock );
+		$this->assertEquals(
+			new Item( new ItemId( 'Q42' ) ),
+			$itemApiLookup->getItemForId( new ItemId( 'Q42' ) )
+		);
+	}
+
+	public function testGetItemForIdWithException() {
+		$revisionGetterMock = $this->getMockBuilder( '\Wikibase\Api\Service\RevisionGetter' )
+			->disableOriginalConstructor()
+			->getMock();
+		$revisionGetterMock->expects( $this->once() )
+			->method( 'getFromId' )
+			->with( $this->equalTo( new ItemId( 'Q42' ) ) )
+			->will( $this->returnValue( false ) );
+
+		$itemApiLookup = new ItemApiLookup( $revisionGetterMock );
+
+		$this->setExpectedException( 'Wikibase\DataModel\Entity\ItemNotFoundException');
+		$this->assertEquals(
+			new Item( new ItemId( 'Q42' ) ),
+			$itemApiLookup->getItemForId( new ItemId( 'Q42' ) )
+		);
+	}
+} 

--- a/tests/unit/Api/RevisionGetterTest.php
+++ b/tests/unit/Api/RevisionGetterTest.php
@@ -40,10 +40,10 @@ class ItemApiLookupTest extends \PHPUnit_Framework_TestCase {
 
 		$itemApiLookup = new ItemApiLookup( $revisionGetterMock );
 
-		$this->setExpectedException( 'Wikibase\DataModel\Entity\ItemNotFoundException');
+		$this->setExpectedException( 'Wikibase\DataModel\Entity\ItemNotFoundException' );
 		$this->assertEquals(
 			new Item( new ItemId( 'Q42' ) ),
 			$itemApiLookup->getItemForId( new ItemId( 'Q42' ) )
 		);
 	}
-} 
+}


### PR DESCRIPTION
Implements this interface introduced in DataModel. It may be useful in order to use easily small libraries depending only on WikibaseDataModel.