### PR TITLE
Always set 'clear' in RevisionSaver

### DIFF
--- a/src/Api/Service/RevisionSaver.php
+++ b/src/Api/Service/RevisionSaver.php
@@ -74,9 +74,13 @@ class RevisionSaver {
 		$entityId = $entity->getId();
 		if( !is_null( $entityId ) ) {
 			$params['id'] = $entityId->getSerialization();
-			if( $entity->isEmpty() ) {
-				$params['clear'] = 'true';
-			}
+
+			// Always clear so that removing elements is possible
+			$params['clear'] = 'true';
+			// Add more detail to the default "Cleared an entity" summary
+			// Note: this is later overridden if a summary is provided in the EditInfo
+			$params['summary'] = 'Edited an ' . $entity->getType();
+
 		} else {
 			$params['new'] = $entity->getType();
 		}


### PR DESCRIPTION
As reported by bene its rather hard to change
lots of things in an entity currently due to
what exactly the wbeditentity module expects
client to do.

Thus we will always pass the clear param
so that the entity we send is actually set!