### PR TITLE
Correcting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ use Wikibase\DataModel\ItemContent;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\DataModel\Entity\PropertyId;
 use DataValues\StringValue;
-use UsageException;
+use Mediawiki\Api\UsageException;
 
 // Load all of the things
 require_once( __DIR__ . "/vendor/autoload.php" );


### PR DESCRIPTION
UsageException is unkown (and issues a warning) unless you give the full namespace
This is the error message in my error_log: PHP Warning:  The use statement with non-compound name 'UsageException' has no effect in /data/project/ytcleaner/public_html/invokecleaner.php on line 10
