### PR TITLE
Specify allowed PHPUnit versions to prevent unintended upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - composer install
 
 script:
-  - cd tests/unit && phpunit --coverage-clover=coverage.clover && cd ../../
+  - cd tests/unit && ../../vendor/bin/phpunit --coverage-clover=coverage.clover && cd ../../
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 		"wikibase/data-model-serialization": "~2.0"
 	},
 	"require-dev": {
+		"phpunit/phpunit": "~4.8|~5.0",
 		"data-values/data-values": "~1.0.0",
 		"data-values/common": "~0.3.0",
 		"data-values/geo": "~1.0|~0.2.0",

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -17,6 +17,6 @@ chdir( __DIR__ . '/../../' );
 passthru( 'composer dump-autoload' );
 chdir( $pwd );
 
-$autoloader = require_once( __DIR__ . '/../../vendor/autoload.php' );
+$autoloader = require( __DIR__ . '/../../vendor/autoload.php' );
 
 $autoloader->addPsr4( 'Wikibase\\Api\\Test\\', __DIR__ );


### PR DESCRIPTION
The current `master` branch is failing on Travis because PHPUnit was upgraded to `^6.0` for PHP 7 (which introduced namespaced classes). After restricting the allowed PHPUnit versions, the tests should be green again.

As soon as support for PHP 5.5 is dropped (which is EOL anyway), the new, namespaced PHPUnit classes could be used. The forward-compatibility layer of PHPUnit 5.x should be sufficient to support PHP >5.6 for the time being.