### PR TITLE
Missing Setting of parameter from editInfo object

### DIFF
--- a/src/Api/Service/StatementCreator.php
+++ b/src/Api/Service/StatementCreator.php
@@ -70,6 +70,21 @@ class StatementCreator {
 			$params['value'] = json_encode( $serializedDataValue['value'] );
 		}
 
+		if( $editInfo !== null ) {
+
+			if( $editInfo->getBot() ) {
+				$params['bot'] = true;
+			}
+			if( $editInfo->getMinor() ) {
+				$params['minor'] = true;
+			}
+			$summary = $editInfo->getSummary();
+			if( !empty( $summary ) ) {
+				$params['summary'] = $summary;
+			}
+
+		}
+			
 		$result = $this->api->postRequest( 'wbcreateclaim', $params, $editInfo );
 		return $result['claim']['id'];
 	}


### PR DESCRIPTION
missing code extracted from
https://github.com/addwiki/wikibase-api/blob/master/src/Api/Service/RevisionSaver.php

(if maxlag will be included into editInfo object, this parameter should be checked, too)