### PR TITLE
Unnecessary save

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ if( $statementList->getByPropertyId( PropertyId::newFromNumber( 1320 ) )->isEmpt
         'Q777'
     );
 }
-$saver->save( $revision );
 ```
 
 #### Remove a statement using a GUID


### PR DESCRIPTION
$statementCreator->create already saves the created statement, the revision save at the end of the code is unnecessary (and misleading).
Btw: Maybe it is a good idea, to list the methods, which update wikidata immediately and which ones just change local objects